### PR TITLE
chore: Migrate Dockerfile to Eclipse Temurin base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Multi-stage build for Golden Raspberry Awards API with Java 23
+# Using Eclipse Temurin (maintained alternative to deprecated OpenJDK images)
 
 # Build stage
-FROM openjdk:23-jdk-slim AS builder
+FROM eclipse-temurin:23-jdk AS builder
 
 WORKDIR /app
 
@@ -22,11 +23,11 @@ COPY src ./src/
 RUN ./mvnw clean package -DskipTests
 
 # Runtime stage
-FROM openjdk:23-jre-slim
+FROM eclipse-temurin:23-jre
 
 # Install curl for health checks and debugging
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
@@ -52,7 +53,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1
 
 # JVM optimization arguments for Java 23
-ENV JAVA_OPTS="-Xmx512m -Xms256m -XX:+UseG1GC -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom --enable-preview"
+ENV JAVA_OPTS="-Xmx512m -Xms256m -XX:+UseG1GC -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom"
 
 # Run the application
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
- Replaced deprecated OpenJDK images with official Eclipse Temurin images for builder and runtime stages.
- Improved Docker image dependencies by using `--no-install-recommends` for apt packages.
- Removed `--enable-preview` JVM flag for cleaner runtime environment.